### PR TITLE
Update README to add action command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ jobs:
 | `address` | ArgoCD server address. |
 | `token` | ArgoCD Token. |
 | `appName` | Application name to sync. |
+| `action` | ArgoCD action to perform
 
 ## Examples
 
@@ -57,6 +58,7 @@ jobs:
           address: "vault.example.com"
           token: ${{ secrets.ARGOCD_TOKEN }}
           appName: "my-example-app"
+          action: sync
 ```
 
 ## Publishing

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Sync ArgoCD Application
-        uses: omegion/argocd-actions@master
+        uses: omegion/argocd-actions@v1
         with:
           address: "vault.example.com"
           token: ${{ secrets.ARGOCD_TOKEN }}


### PR DESCRIPTION
The sync example in the README is configured incorrectly.
It left out the `action` command resulting in the error shown in #16 .

Furthermore it also used the docker tag `master` which doesn't exist.